### PR TITLE
Use localhost as destination address explicitly in liveness/readiness probes.

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -40,7 +40,7 @@ spec:
             exec:
               command:
               - "/usr/bin/grpc_health_probe"
-              - "-addr=:{{ .Values.master.port | default "8080" }}"
+              - "-addr=localhost:{{ .Values.master.port | default "8080" }}"
               {{- if .Values.tls.enable }}
               - "-tls"
               - "-tls-ca-cert=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
@@ -53,7 +53,7 @@ spec:
             exec:
               command:
               - "/usr/bin/grpc_health_probe"
-              - "-addr=:{{ .Values.master.port | default "8080" }}"
+              - "-addr=localhost:{{ .Values.master.port | default "8080" }}"
               {{- if .Values.tls.enable }}
               - "-tls"
               - "-tls-ca-cert=/etc/kubernetes/node-feature-discovery/certs/ca.crt"


### PR DESCRIPTION
👋 Hello - I noticed that in the `grpc_health_probe -h` output, we're told to add a `host:port` combination.

```
Usage:
  -addr string
        (required) tcp host:port to connect
```

It is nice that this generally works without the hostname...

However, in some situations, there are proxies being used implicitly, and in order to get around those proxies, we need to set environment variables like NO_PROXY or HTTPS_PROXY and so on. But, if there is not hostname, those values cannot be utilized I think. This is also not a value exposed by the template, so while we can change the port, we cannot change the hostname.

Alternatively, we could also make the value `localhost` a templated variable.

Anyway thought I would just make this suggestion since it was an issue I ran into and am trying to figure out how to workaround without forking the entire chart.

Best,
Xander

